### PR TITLE
Hides mongo's password in logs

### DIFF
--- a/src/server/database/index.js
+++ b/src/server/database/index.js
@@ -16,7 +16,7 @@ const getMongoConfig = config => ({
 
 const mongoConnectionMessage = config => {
   const mongo = getMongoConfig(config);
-  return `${mongo.db} with user ${mongo.user}`
+  return `${mongo.db} database with user ${mongo.user}`
 }
 
 const getMongoURL = config => {
@@ -42,12 +42,12 @@ export const connect = async (config, dboptions) => {
 
     // Connection throws an error
     mongoose.connection.on('error', err => {
-      log.info(`MongoDB connection error: ${getMongoURL(config)}: ${err}`);
+      log.info(`MongoDB was not able to connect to ${mongoConnectionMessage(config)}`);
     });
 
     // Connection is disconnected
     mongoose.connection.on('disconnected', err => {
-      log.info(`MongoDB disconnected: ${getMongoURL(config)}`);
+      log.info(`MongoDB disconnected from: ${mongoConnectionMessage(config)}`);
     });
 
     mongoose.Promise = global.Promise;

--- a/src/server/database/index.js
+++ b/src/server/database/index.js
@@ -6,15 +6,26 @@ const log = require('../../config/log').logger();
 let connectionDB;
 let connectionDBNative;
 
-const getMongoURL = config => {
-  const servers = config.get('database.mongodb.servers').join(',');
-  const url = `mongodb://${encodeURIComponent(
-    config.get('database.mongodb.user')
-  )}:${encodeURIComponent(config.get('database.mongodb.pass'))}@${servers}`;
+const getMongoConfig = config => ({
+  user: config.get('database.mongodb.user'),
+  pass: config.get('database.mongodb.pass'),
+  db: config.get('database.mongodb.db'),
+  servers: config.get('database.mongodb.servers'),
+  authMechanism: config.get('database.mongodb.authMechanism')
+})
 
-  return `${url}/${config.get(
-    'database.mongodb.db'
-  )}?authMechanism=${config.get('database.mongodb.authMechanism')}`;
+const mongoConnectionMessage = config => {
+  const mongo = getMongoConfig(config);
+  return `${mongo.db} with user ${mongo.user}`
+}
+
+const getMongoURL = config => {
+  const mongo = getMongoConfig(config);
+
+  const servers = mongo.servers.join(',');
+  const url = `mongodb://${encodeURIComponent(mongo.user)}:${encodeURIComponent(mongo.pass)}@${servers}`;
+
+  return `${url}/${mongo.db}?authMechanism=${mongo.authMechanism}`;
 };
 
 /**
@@ -26,7 +37,7 @@ export const connect = async (config, dboptions) => {
   if (!connectionDB) {
     // Successfully connected
     mongoose.connection.on('connected', err => {
-      log.info(`MongoDB connected on ${getMongoURL(config)}`);
+      log.info(`MongoDB connected to ${mongoConnectionMessage(config)}`);
     });
 
     // Connection throws an error


### PR DESCRIPTION
## 🛠️ Changes
Se modificó el mensaje de conexión en los logs para ocultar la contraseña de mongodb. 
Se creó un helper para hacer el código más limpio y retonar solo los valores necesarios en el mensaje, manteniendo intacta la configuración original usada para la conexión.

## 📝 Associated issues
Resolves LIB-587
